### PR TITLE
Fix usage of obsolete API

### DIFF
--- a/src/ESP_Wunderground_PWS.cpp
+++ b/src/ESP_Wunderground_PWS.cpp
@@ -130,7 +130,7 @@ int16_t Wunderground::send_update(bool realtime)
     final_query += _query;
     
     // Send the query
-    _http.begin(final_query);
+    _http.begin(wifiClient, final_query);
     
     int16_t ret_code = _http.GET();
 

--- a/src/ESP_Wunderground_PWS.h
+++ b/src/ESP_Wunderground_PWS.h
@@ -53,6 +53,7 @@ class Wunderground
 		String _API_URI				= "/weatherstation/updateweatherstation.php";
 
 		String _ID, _pass, _query;
+		WiFiClient wifiClient;
 		HTTPClient _http;
 
 		bool _date_set  = false;


### PR DESCRIPTION
API used by this library is now defined as: `

    // old API is now explicitly forbidden
    bool begin(String url)  __attribute__ ((error("obsolete API, use ::begin(WiFiClient, url)")));
`
Adjusting to use begin(WiFiClient, url)